### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,13 +10,13 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-readMCP KEYWORD2
+readMCP	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-MCP3008 KEYWORD2
+MCP3008	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords